### PR TITLE
Don't swallow errors logged at the top level

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -271,6 +271,9 @@ function makeEventError(error) {
  * @return {Array} The list of errors extracted from the object.
  */
 function extractErrors(obj) {
+  if (obj instanceof Error) {
+    return [obj];
+  }
   var errors = [];
 
   if (obj) {

--- a/test/test.js
+++ b/test/test.js
@@ -353,7 +353,46 @@ describe('logger', function() {
       ]);
     });
 
-    it('should not produce log messages bellow warnings', function() {
+    it('should produce log messages with top-level errors', function() {
+      var messages = [];
+      var logger = new ecslogs.Logger({
+        output: function(msg) {
+          messages.push(JSON.parse(msg))
+        },
+        timestamp: now,
+        hostname: 'localhost'
+      });
+
+      logger.error('something went wrong', new TestError('oops!'));
+
+      assert.deepEqual(messages, [
+        {
+          level: 'ERROR',
+          time: '2016-07-02T21:11:47.000Z',
+          info: {
+            host: 'localhost',
+            errors: [
+              {
+                type: 'TestError',
+                error: 'oops!',
+                stack: [
+                  'at test3 (test.js:3:1)',
+                  'at test2 (test.js:2:1)',
+                  'at test1 (test.js:1:1)'
+                ],
+              }
+            ]
+          },
+          data: {
+            message: 'oops!',
+            stack: "Error: oops!\n\tat test3 (test.js:3:1)\n\tat test2 (test.js:2:1)\n\tat test1 (test.js:1:1)\n"
+          },
+          message: 'something went wrong'
+        }
+      ]);
+    });
+
+    it('should not produce log messages below warnings', function() {
       var messages = [];
       var logger = new ecslogs.Logger({
         output: function(msg) {


### PR DESCRIPTION
Previously errors were expected to be logged as e.g.

    logger.warn('problem', {error: new MyError('foo')})

However in some cases we were logging errors as e.g.

    logger.warn('problem', new MyError('foo'))

In the latter case, nothing about the error was getting written to the log
file. Check for this top-level error case.

I'm not sure the behavior is appropriate - please double check that the test
does the right thing.