### PR TITLE
Use node v6.9.2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 0.12
+    version: 6.9.2
 
 test:
   override:


### PR DESCRIPTION
Running lint checks on Node 0.12 fails because eslint uses a `const`
declaration - I'm not sure when that was added and a little confused since
eslint's CHANGELOG does not mention this breaking change, but this should
hopefully clear up the problem anyway.