### PR TITLE
feat: safe-json-stringify for encoding log events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ var os = require('os');
 var util = require('util');
 var winston = require('winston');
 var typeName = require('type-name');
+var stringify = require('safe-json-stringify');
 
 /**
  * Levels maps the winston log levels exposed by the ecslogs.Logger..
@@ -182,7 +183,7 @@ Transport.prototype.log = function(level, message, meta, callback) {
  */
 function Formatter(options) {
   function format(entry) {  // eslint-disable-line
-    return JSON.stringify(makeEvent(entry, format.hostname));
+    return stringify(makeEvent(entry, format.hostname));
   }
 
   if (!options) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "author": "Achille Roussel",
   "license": "MIT",
   "dependencies": {
+    "safe-json-stringify": "^1.2.0",
     "type-name": "^2.0.1",
     "winston": "^2.2.0"
   },


### PR DESCRIPTION
Currently, this transport will throw when attempting to encode objects with circular references. This additional dependency fixes that problem and prevents simple logs from crashing an entire server.